### PR TITLE
tcp-connect to other hosts than "localhost"

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,6 +9,8 @@ import (
 type Config struct {
 	Host     string `json:"host"`
 	Port     int    `json:"port"`
+	RemoteHost string `json:"remoteHost"`
+
 	UserName string `json:"username"`
 	Password string `json:"password"`
 	ClientID string `json:"clientId"`

--- a/config.go
+++ b/config.go
@@ -9,7 +9,7 @@ import (
 type Config struct {
 	Host     string `json:"host"`
 	Port     int    `json:"port"`
-	RemoteHost string `json:"remoteHost"`
+	RemoteHost string `json:"remotehost"`
 
 	UserName string `json:"username"`
 	Password string `json:"password"`
@@ -33,5 +33,10 @@ func ReadConfig(filePath string) (Config, error) {
 	if err := json.Unmarshal(buf, &ret); err != nil {
 		return ret, fmt.Errorf("read config marshal error, %w", err)
 	}
+
+	if (ret.RemoteHost == "") {
+		ret.RemoteHost = "localhost"
+	}
+
 	return ret, nil
 }

--- a/tcp.go
+++ b/tcp.go
@@ -26,9 +26,10 @@ type TCPConnection struct {
 	tcpClosedCh chan error
 }
 
-func NewTCPConnection(port int, tun *Tunnel) (*TCPConnection, error) {
+func NewTCPConnection(port int, host string, tun *Tunnel) (*TCPConnection, error) {
 	ret := TCPConnection{
 		port:        port,
+		remoteHost:  host,
 		tunnel:      tun,
 		tcpClosedCh: tun.tcpClosedCh,
 	}

--- a/tcp.go
+++ b/tcp.go
@@ -21,6 +21,7 @@ type TCPConnection struct {
 
 	conn        net.Conn
 	isLocal     bool
+	remoteHost  string
 	tunnel      *Tunnel
 	tcpClosedCh chan error
 }
@@ -40,7 +41,7 @@ func (con *TCPConnection) connect(ctx context.Context) (net.Conn, error) {
 	zap.S().Debugw("start connecting", zap.Int("local_port", con.tunnel.LocalPort))
 
 	// TODO: Does we want to any hosts instead of localhost?
-	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", con.port))
+	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", con.remoteHost, con.port))
 	if err != nil {
 		return nil, fmt.Errorf("ResolveTCPAddr error, %w", err)
 	}

--- a/tunnel.go
+++ b/tunnel.go
@@ -42,7 +42,7 @@ func NewTunnelFromConnect(ctx context.Context, mqttBroker *mqttBroker, conn net.
 		mqttBroker:  mqttBroker,
 	}
 
-	tcon, err := NewTCPConnection(ret.LocalPort, ret)
+	tcon, err := NewTCPConnection(ret.LocalPort, mqttBroker.conf.RemoteHost, ret)
 	if err != nil {
 		return nil, fmt.Errorf("new tcp connection error, %w", err)
 	}

--- a/tunnel.go
+++ b/tunnel.go
@@ -77,7 +77,7 @@ func NewTunnelFromControl(ctx context.Context, mqttBroker *mqttBroker, ctl contr
 		mqttBroker:  mqttBroker,
 	}
 
-	tcon, err := NewTCPConnection(ret.LocalPort, &ret)
+	tcon, err := NewTCPConnection(ret.LocalPort, mqttBroker.conf.RemoteHost, &ret)
 	if err != nil {
 		return nil, fmt.Errorf("new tcp connection error, %w", err)
 	}


### PR DESCRIPTION
added a config-value "remotehost" that is to be used by new tcp-connections to connect to (instead of _localhost_); the default value (if not supplied) is "localhost", so the behavior of 'old' config-files (w/o _remotehost_) is not unchanged.